### PR TITLE
Implementation of extra fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ The shortcode has following parameters:
 
 * **group**: (Optional) Filter dataset results by showing only those belonging to a certain group.
 
+* **type**: (Optional) Filter dataset results by showing only those belonging to a certain dataset-type.
+
 * **include_fields_dataset**:  (Optional) Comma-separated.
 Per default, this shortcode shows only title (with link to the dataset's URL) and notes of the CKAN dataset (See http://demo.ckan.org/api/3/action/package_search?q=spending). A list of attributes can be specified to present more information. Possible values: "title", "notes", "url", "license", "license_url" "metadata_created", "metadata_modified", "author" , "author_email"
 
@@ -235,6 +237,8 @@ Examples:
 [wpckan_query_datasets query="elections" include_fields_dataset="title,notes,license" include_fields_resources="name,description,created"]
 [wpckan_query_datasets limit="3" filter_fields='{"spatial-text":"England","date":"2015"}']
 [wpckan_query_datasets query="coal" blank_on_empty='true']
+// show all datasets of the dataset-type library record
+[wpckan_query_datasets query="*:*" type="library_record"]
 ```
 
 ```html

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Specify the name (Not title) of an organization available on the target CKAN ins
 Note: If both **group** and **organization** parameters are specified then the dataset has to be asssigned to both in order to be returned by the shortcode.
 
 * **include_fields_dataset**:  (Optional) Comma-separated string.
-Per default, this shortcode shows only title and notes of the CKAN dataset (See http://demo.ckan.org/api/3/action/package_search?q=spending). A list of attributes can be specified to present more information. Possible values: "title", "notes", "url", "license", "license_url" "metadata_created", "metadata_modified", "author" , "author_email"
+Per default, this shortcode shows only title and notes of the CKAN dataset (See http://demo.ckan.org/api/3/action/package_search?q=spending). A list of attributes can be specified to present more information. Possible values: "title", "notes", "url", "license_id", "license_url" "metadata_created", "metadata_modified", "author" , "author_email"
 
 * **include_fields_resources**:  (Optional) Comma-separated string.
 Per default, this shortcode shows only name, description and format of the resources (See http://demo.ckan.org/api/3/action/package_search?q=spending). A list of attributes can be specified to present more information. Possible values: "name", "description", "revision_timestamp", "format", "created"

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ So, mind that the CKAN instance which this plugin is used with needs to allow al
 # Requirements
 
 * PHP 5 >= 5.2.0
+* PHP Curl extension (in ubuntu sudo apt-get install php5-curl)
 
 # Uses
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Per default, this shortcode shows only title and notes of the CKAN dataset (See 
 * **include_fields_resources**:  (Optional) Comma-separated string.
 Per default, this shortcode shows only name, description and format of the resources (See http://demo.ckan.org/api/3/action/package_search?q=spending). A list of attributes can be specified to present more information. Possible values: "name", "description", "revision_timestamp", "format", "created"
 
+* **include_fields_exra**: (Optional) Comma-separated string.
+This shortcode outputs extra metadatafields. A list of attributes can specified to present more Information.
+
 * **limit**: (Optional) Number.
 Limits the amount of datasets shown by the shortcode string.
 

--- a/templates/dataset_list.php
+++ b/templates/dataset_list.php
@@ -26,7 +26,7 @@
   <ul>
 
   <?php foreach ($data as $dataset){ ?>
-    <?php //var_dump($dataset["license_id"]);?>
+
 
     <li>
       <div class="wpckan_dataset">
@@ -85,11 +85,11 @@
               <?php } ?>
             </ul>
             <?php if (array_key_exists("include_fields_extra",$atts))?>
-              <div class="wpckan_dataset_exras">
+              <div class="wpckan_dataset_extras">
                 <ul>
                   <?php foreach ($include_fields_extra as $extra) {
                     if (array_key_exists($extra,$dataset) && !wpckan_is_null_or_empty_string($dataset[$extra]) && in_array($extra,$include_fields_extra)) {?>
-                      <li><?php echo $dataset[$extra];?></li>
+                      <li class="wpkan_dataset_extras-<?php echo $extra;?>"><?php echo $dataset[$extra];?></li>
                     <?php } ?>
                 <?php } ?>
                 </ul>

--- a/templates/dataset_list.php
+++ b/templates/dataset_list.php
@@ -21,6 +21,7 @@
 <div class="wpckan_dataset_list">
   <ul>
   <?php foreach ($data as $dataset){ ?>
+    <?php //var_dump($dataset["license_id"]);?>
     <li>
       <div class="wpckan_dataset">
         <?php if (array_key_exists("title",$dataset) && !wpckan_is_null_or_empty_string($dataset["title"]) && in_array("title",$include_fields_dataset)) {?>
@@ -32,8 +33,8 @@
         <?php if (array_key_exists("url",$dataset) && !wpckan_is_null_or_empty_string($dataset["url"]) && in_array("url",$include_fields_dataset)) {?>
           <div class="wpckan_dataset_url"><?php echo $dataset["url"] ?></div>
         <?php } ?>
-        <?php if (array_key_exists("license",$dataset) && !wpckan_is_null_or_empty_string($dataset["license"]) && in_array("license",$include_fields_dataset)) {?>
-          <div class="wpckan_dataset_license"><?php echo $dataset["license"] ?></div>
+        <?php if (array_key_exists("license_id",$dataset) && !wpckan_is_null_or_empty_string($dataset["license_id"]) && in_array("license_id",$include_fields_dataset)) {?>
+          <div class="wpckan_dataset_license"><?php echo $dataset["license_id"] ?></div>
         <?php } ?>
         <?php if (array_key_exists("license_url",$dataset) && !wpckan_is_null_or_empty_string($dataset["license_url"]) && in_array("license_url",$include_fields_dataset)) {?>
           <div class="wpckan_dataset_license_url"><?php echo $dataset["license_url"] ?></div>

--- a/templates/dataset_list.php
+++ b/templates/dataset_list.php
@@ -14,14 +14,20 @@
   if (array_key_exists("related_dataset",$atts)) $count = count($atts["related_dataset"]);
   if (array_key_exists("count",$atts)) $count = $atts["count"];
 
+// field extras
+  $include_fields_extra = array();
+  if (array_key_exists("include_fields_extra",$atts))
+    $include_fields_extra = explode(",",$atts["include_fields_extra"]);
   // insert type
 
 ?>
 
 <div class="wpckan_dataset_list">
   <ul>
+
   <?php foreach ($data as $dataset){ ?>
     <?php //var_dump($dataset["license_id"]);?>
+
     <li>
       <div class="wpckan_dataset">
         <?php if (array_key_exists("title",$dataset) && !wpckan_is_null_or_empty_string($dataset["title"]) && in_array("title",$include_fields_dataset)) {?>
@@ -74,9 +80,23 @@
                       <?php } ?>
                   </div>
                 </li>
+
+
               <?php } ?>
             </ul>
+            <?php if (array_key_exists("include_fields_extra",$atts))?>
+              <div class="wpckan_dataset_exras">
+                <ul>
+                  <?php  foreach ($include_fields_extra as $extra) {
+                    if (array_key_exists($extra,$dataset) && !wpckan_is_null_or_empty_string($dataset[$extra]) && in_array($extra,$include_fields_extra)) ?>
+                      <li><?php echo $dataset[$extra];?></li>
+                <?php } ?>
+                </ul>
+              </div>
+
           </div>
+
+
         <?php } ?>
       </div>
     </li>

--- a/templates/dataset_list.php
+++ b/templates/dataset_list.php
@@ -13,6 +13,9 @@
     $include_fields_resources = explode(",",$atts["include_fields_resources"]);
   if (array_key_exists("related_dataset",$atts)) $count = count($atts["related_dataset"]);
   if (array_key_exists("count",$atts)) $count = $atts["count"];
+
+  // insert type
+
 ?>
 
 <div class="wpckan_dataset_list">

--- a/templates/dataset_list.php
+++ b/templates/dataset_list.php
@@ -87,9 +87,10 @@
             <?php if (array_key_exists("include_fields_extra",$atts))?>
               <div class="wpckan_dataset_exras">
                 <ul>
-                  <?php  foreach ($include_fields_extra as $extra) {
-                    if (array_key_exists($extra,$dataset) && !wpckan_is_null_or_empty_string($dataset[$extra]) && in_array($extra,$include_fields_extra)) ?>
+                  <?php foreach ($include_fields_extra as $extra) {
+                    if (array_key_exists($extra,$dataset) && !wpckan_is_null_or_empty_string($dataset[$extra]) && in_array($extra,$include_fields_extra)) {?>
                       <li><?php echo $dataset[$extra];?></li>
+                    <?php } ?>
                 <?php } ?>
                 </ul>
               </div>

--- a/utils/wpckan_api.php
+++ b/utils/wpckan_api.php
@@ -67,13 +67,15 @@
       if (isset($atts['organization'])) $filter = $filter . "+owner_org:" . $atts['organization'];
       if (isset($atts['organization']) && isset($atts['group'])) $filter = $filter . " ";
       if (isset($atts['group'])) $filter = $filter . "+groups:" . $atts['group'];
+      // enables filter by dataset type functionality like http://192.168.33.10:8081/api/3/action/package_search?fq=type:laws_record
+      if (isset($atts['type'])) $filter = $filter . "+type:" . $atts['type'];
       if (!is_null($filter)){
         $arguments["fq"] = $filter;
       }
       $command = $ckanClient->getCommand($commandName,$arguments);
       $response = $command->execute();
 
-      wpckan_log("wpckan_api_query_datasets commandName: " . $commandName . " arguments: " . print_r($arguments,true) . " settings: " . print_r($settings,true));
+      wpckan_log("wpckan_api_query_datasets commandName:" . $commandName . " arguments: " . print_r($arguments,true) . " settings: " . print_r($settings,true));
 
       if ($response['success']==false){
         wpckan_api_call_error("wpckan_api_query_datasets",null);
@@ -82,7 +84,7 @@
     } catch (Exception $e){
         wpckan_api_call_error("wpckan_api_query_datasets",$e->getMessage());
     }
-
+    // RESULTS
     return $response['result'];
 
   }
@@ -409,25 +411,22 @@
   function wpckan_api_parameter_error($function,$message){
     $error_log = "ERROR Parameters on " . $function . " message: " . $message;
     $error_message = "Something went wrong, check your connection details";
-    //wpckan_log($error_log);
+    wpckan_log($error_log);
     throw new ApiParametersException($error_message);
-    // return __($error_message,'wpckan_api_parameter_error');
   }
 
   function wpckan_api_call_error($function,$message){
     $error_log = "ERROR API CALL on " . $function . " message: " . $message;
     $error_message = "Something went wrong, check your connection details";
-    //wpckan_log($error_log);
+    wpckan_log($error_log);
     throw new ApiCallException($error_message);
-    // return __($error_message,'wpckan_api_call_error');
   }
 
   function wpckan_api_settings_error($function,$message){
     $error_log = "ERROR SETTINGS on " . $function . " message: " . $message;
     $error_message = "Please, specify CKAN URL and API Key";
-    // wpckan_log($error_log);
+    wpckan_log($error_log);
     throw new ApiSettingsException($error_message);
-    // return __($error_message,'wpckan_api_settings_error');
   }
 
 ?>

--- a/wpckan.php
+++ b/wpckan.php
@@ -3,7 +3,7 @@
  * Plugin Name: wpckan
  * Plugin URI: http://www.lifeformapps.com/portfolio/wpckan/
  * Description: wpckan is a wordpress plugin that exposes a series of functionalities to bring content stored in CKAN to Wordpress' UI and also provide mechanisms for archiving content generated on Wordpress into a CKAN instance.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Alex Corbi (mail@lifeformapps.com)
  * Author URI: http://www.lifeformapps.com
  * License: GPLv3


### PR DESCRIPTION
Due to requirements for law's integration it is beneficial beeing able to query for extra fields.
Therefore the shortcode "include_fields_extra" has been added to the plugin. In the example below the complete shortcode looks like
`````
[wpckan_query_datasets query="*:*" type="laws_record" include_fields_extra="odm_laws_status,odm_effective_date"]
`````
and produces the following output
![image](https://cloud.githubusercontent.com/assets/11522213/12010941/75dfaa06-acbb-11e5-9777-99a2cd555086.png)
