### PR TITLE
Fixes #197

### DIFF
--- a/templates/dataset-list.php
+++ b/templates/dataset-list.php
@@ -44,8 +44,11 @@
 						if (isset($dataset[$field_name])):?>
 	            <div class="wpckan_dataset_<?php echo($field_name); ?>">
 	              <?php
-								$to_print = (is_array($dataset[$field_name]) && isset($dataset[$field_name][$current_language])) ? $dataset[$field_name][$current_language] : $dataset[$field_name];
-	              if ($should_link_to_dataset): ?>
+                $to_print = $dataset[$field_name];
+                if (is_array($dataset[$field_name])):
+                  $to_print =  !empty($dataset[$field_name][$current_language]) ? $dataset[$field_name][$current_language] : $dataset[$field_name]["en"];
+                endif;
+								if ($should_link_to_dataset): ?>
 	                <a <?php if ($target_blank_enabled){ echo 'target="_blank"';} ?>  href="<?php echo wpckan_get_link_to_dataset($dataset["name"]) ?>">
 										<?php echo $to_print; ?>
 									</a>
@@ -73,8 +76,11 @@
 												if (isset($resource[$field_name])):?>
 	                        <div class="wpckan_resource_<?php echo($field_name); ?>">
 	                          <?php
-														$to_print = (is_array($resource[$field_name]) && isset($resource[$field_name][$current_language])) ? $resource[$field_name][$current_language] : $resource[$field_name];
-	                          if ($should_link_to_dataset): ?>
+                            $to_print = $resource[$field_name];
+                            if (is_array($resource[$field_name])):
+                              $to_print =  !empty($resource[$field_name][$current_language]) ? $resource[$field_name][$current_language] : $resource[$field_name]["en"];
+                            endif;
+														if ($should_link_to_dataset): ?>
 															<a <?php if ($target_blank_enabled){ echo 'target="_blank"';} ?>  href="<?php echo wpckan_get_link_to_dataset($resource["name"]) ?>">
 																<?php echo $to_print; ?>
 															</a>


### PR DESCRIPTION
@Huyeng this PR fixes the issue that you had reported on https://github.com/OpenDevelopmentMekong/wp-odm_theme/issues/634 by implementing a fallback to english in case the listed CKAN records do not have fields in the currently selected language ( in this case Khmer title). The result is as pictured below and in the following URL:  https://pp.opendevelopmentcambodia.net/km/profiles/prey-lang-landscape/

![screenshot from 2016-12-06 16-14-10](https://cloud.githubusercontent.com/assets/384894/20930861/5957fcde-bbcf-11e6-8b38-c3371c155049.png)

My suggestion is that the data team translate those records once they are identified.