### PR TITLE
updated license url/function

### DIFF
--- a/utils/wpckan-utils.php
+++ b/utils/wpckan-utils.php
@@ -672,9 +672,9 @@
   }
 
   function wpckan_get_license_list(){
-    $path_to_license_file = wpckan_get_ckan_domain() . '/licenses.json';
+    $path_to_license_file = wpckan_get_ckan_domain() . 'api/action/license_list';
 		$json_file = wpckan_do_curl($path_to_license_file);
-		return json_decode($json_file);
+		return json_decode($json_file)['result'];
   }
 
   function wpckan_is_date($value){


### PR DESCRIPTION
This should fix the large number of 404's for the `/licenses.json` url on ckan.

@S-mardii I've put this on pp, I can't actually figure out where it's called in the interface, and I'd like some confirmation that it's not breaking before a push to prod. 

https://github.com/OpenDevelopmentMekong/IssuesManagement/issues/815