### PR TITLE
Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "wpckan",
+  "name": "opendevmekong/wpckan",
   "version": "1.3.1",
   "description": "wpckan is a wordpress plugin that exposes a series of functionalities to bring content stored in CKAN to Wordpress' UI and also provide mechanisms for archiving content generated on Wordpress into a CKAN instance.",
   "repositories": [
@@ -13,10 +13,11 @@
     }
   ],
   "require": {
+    "psr/log": "1.1.4",
     "silex/ckan_client": "dev-master",
-    "analog/analog": "dev-master",
+    "analog/analog": "1.0.16",
     "twitter/typeahead.js": "dev-master",
     "gilbitron/php-simplecache": "dev-master",
-    "doctrine/cache" : "*"
+    "doctrine/cache": "1.13.*"
   }
 }

--- a/utils/datastore-api.php
+++ b/utils/datastore-api.php
@@ -5,7 +5,7 @@ function wpckan_get_or_cache($url,$id){
   if (!$id) {
     return  wpckan_do_curl($url);
   }
-  
+
   $json = "{}";
   $hashed_id = "wpckan.".md5($id);
 
@@ -23,8 +23,10 @@ function wpckan_get_or_cache($url,$id){
      $json = wpckan_do_curl($url);
    }
    if (!(strpos($json, '"success": false') !== false && !empty($hashed_id))) {
-     wpckan_log("Saving $url to cache");
-     $GLOBALS['cache']->save($hashed_id, $json, $GLOBALS['cache_time']);
+ 		if ($GLOBALS['cache'] !== null) {
+			wpckan_log("Saving $url to cache");
+			$GLOBALS['cache']->save($hashed_id, $json, $GLOBALS['cache_time']);
+		} else wpckan_log('cache is null');
    }
 
    return $json;

--- a/wpckan.php
+++ b/wpckan.php
@@ -23,14 +23,21 @@
 
  $cache_path = $GLOBALS['wpckan_options']->get_option('wpckan_setting_cache_path');
  $cache_time = $GLOBALS['wpckan_options']->get_option('wpckan_setting_cache_time');
- if (defined('WP_REDIS_CACHE_HOST')){
-     $redis = new Redis();
-     $redis->pconnect(WP_REDIS_CACHE_HOST, WP_REDIS_CACHE_PORT);
-     $cache = new RedisCache();
-     $cache->setRedis($redis);
-     $GLOBALS['cache'] = $cache;
-     $GLOBALS['cache_time'] = $cache_time;
- }
+  if (defined('WP_REDIS_CACHE_HOST')){
+      try {
+          if (!class_exists('Redis')) {
+              throw new Exception('Redis extension is not installed');
+          }
+          $redis = new Redis();
+          $redis->pconnect(WP_REDIS_CACHE_HOST, WP_REDIS_CACHE_PORT);
+          $cache = new RedisCache();
+          $cache->setRedis($redis);
+          $GLOBALS['cache'] = $cache;
+          $GLOBALS['cache_time'] = $cache_time;
+      } catch (Exception $e) {
+          error_log('WPCKAN Redis Error: ' . $e->getMessage());
+      }
+  }
 
 if (!class_exists('wpckan')) {
     class wpckan


### PR DESCRIPTION
List of update
- add error handling when store cache in detastore-api
- add/update to use some depandency specifles version to avoid error
- define redis host and port

for redis to work you need to install and run Redis Open Source 
 1. redis-server 
 2. php-redis

and you need to define this in wp-config.php

 define('WP_REDIS_CACHE_HOST', 'redis');
 define('WP_REDIS_CACHE_PORT', 6379);
